### PR TITLE
tags improvements

### DIFF
--- a/lib/tag.ex
+++ b/lib/tag.ex
@@ -11,6 +11,7 @@ defmodule TougouBot.Tag do
 
   #at the moment, this will only remember one "word", 
   # anything after whitespace will be dropped
+  Cogs.set_parser(:ntag, &TougouBot.Tag.custom_parser/1)
   Cogs.def ntag(tag, contents) do
     case all_tags[tag] do
       nil -> 
@@ -19,6 +20,19 @@ defmodule TougouBot.Tag do
       _ ->
         Cogs.say @tag_already
     end
+  end
+  def rebuild_string([head | []]) do
+    head
+  end
+  def rebuild_string([head | tail]) do
+    head<>" "<>rebuild_string(tail)
+  end
+  def custom_parser(args) do #parser to make our tag system remember `phrases` not `words`
+    args = String.split(args)
+    arg0 = Enum.at(args, 0)
+    args = Enum.drop(args, 1)
+    args = rebuild_string(args)
+    List.wrap(arg0) ++ List.wrap(args)
   end
   Cogs.def ntag(tag) do
     case all_tags[tag] do

--- a/lib/tag.ex
+++ b/lib/tag.ex
@@ -7,7 +7,7 @@ defmodule TougouBot.Tag do
   use Alchemy.Cogs
 
   #pre-defined messages
-  @tag_already "えー、でも、この言葉もう知てる"
+  @tag_already "へー、でも、この言葉もう知ってる"
 
   #at the moment, this will only remember one "word", 
   # anything after whitespace will be dropped

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TougouBot.Mixfile do
   def project do
     [
       app: :tougou_bot,
-      version: "0.2.3",
+      version: "0.2.4",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
       deps: deps()


### PR DESCRIPTION
Fixed a japanese typo in the tags feature and added a custom parser so that we can remember a phrase over a word as a tag. previously it would drop everything after the first space but now its fine.